### PR TITLE
Changed to create temp file in currect directory.

### DIFF
--- a/buftra.el
+++ b/buftra.el
@@ -56,7 +56,7 @@
   "Formats the current buffer according to the executable"
   (when (not (executable-find executable-name))
     (error (format "%s command not found." executable-name)))
-  (let ((tmpfile (make-temp-file executable-name nil (concat "." file-extension)))
+  (let ((tmpfile (concat (make-temp-name executable-name) "." file-extension))
         (patchbuf (get-buffer-create (format "*%s patch*" executable-name)))
         (errbuf (get-buffer-create (format "*%s Errors*" executable-name)))
         (coding-system-for-read buffer-file-coding-system)


### PR DESCRIPTION
I am not sure if use of make-temp-file should be actually an option, but both py-isort and py-autopep8 work much better if they can find the project-specific defaults. This is accoplished by creating the temp file where the current buffer lives.
